### PR TITLE
Map autoconfig xml string starttls to tls

### DIFF
--- a/lib/Service/AutoConfig/IspDbConfigurationDetector.php
+++ b/lib/Service/AutoConfig/IspDbConfigurationDetector.php
@@ -224,6 +224,13 @@ class IspDbConfigurationDetector {
 			$account->setOutboundUser($user);
 			$account->setOutboundSslMode(strtolower($smtp['socketType']));
 
+			/** mapping 'STARTTLS' expected by e.g. Thunderbird to 'tls' used by mail app */
+			if (strtolower($smtp['socketType']) === 'starttls') {
+				$account->setOutboundSslMode('tls');
+			} else {
+				$account->setOutboundSslMode(strtolower($smtp['socketType']));
+			}
+
 			$a = new Account($account);
 			$transport = $this->smtpClientFactory->create($a);
 			if ($transport instanceof Horde_Mail_Transport_Smtphorde) {


### PR DESCRIPTION
As Thunderbird expects the string "STARTTLS" from the Autoconfig XML*, but Mail App internally uses "tls", starttls is now being mapped to tls.

* source: https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat